### PR TITLE
Check the opt level to determine whether the build is a debug build.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,7 +42,17 @@ fn is_windows() -> bool {
 }
 
 fn is_debug() -> bool {
-  env::var("DEBUG").unwrap() == "true"
+  match &env::var("OPT_LEVEL").unwrap()[..] {
+    "0" => true,
+    "1" | "2" | "3" | "s" | "z" => false,
+    unknown => {
+      println!(
+        "cargo:warning=Unknown opt-level={}, defaulting to release",
+        unknown
+      );
+      false
+    }
+  }
 }
 
 fn lib_names() -> Vec<String> {


### PR DESCRIPTION
Previously we used the DEBUG var, but the `cmake` crate uses opt level to determine which build type to use. This meant users could manually change their opt level (while still being on a debug build) which would make us look for the wrong lib file.

Fixes #4.