### PR TITLE
Add support for target wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "recastnavigation-sys"
-version = "1.0.2"
+version = "1.0.3"
 
 description = "Raw FFI bindings for recastnavigation."
 
@@ -34,7 +34,7 @@ recast = []
 static_assertions = "1.1.0"
 
 [build-dependencies]
-bindgen = "0.64.0"
-cc = "1.0.79"
-cmake = "0.1.49"
-pkg-config = "0.3.26"
+bindgen = "0.69.1"
+cc = "1.0.83"
+cmake = "0.1.50"
+pkg-config = "0.3.28"

--- a/build.rs
+++ b/build.rs
@@ -198,8 +198,8 @@ fn generate_recast_bindings(
     out_file: PathBuf,
   ) {
     let mut builder = bindgen::Builder::default()
-      .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-      .clang_args(["-x", "c++"].iter())
+      .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+      .clang_args(["-x", "c++", "-fvisibility=default"].iter())
       .clang_args(
         include_dirs
           .iter()
@@ -361,8 +361,8 @@ fn generate_inline_bindings(
 ) {
   let mut builder = bindgen::Builder::default()
     .header("inline_lib_src/inline.h")
-    .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-    .clang_args(["-x", "c++"].iter())
+    .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+    .clang_args(["-x", "c++", "-fvisibility=default"].iter())
     .clang_args(
       include_dirs
         .iter()
@@ -412,6 +412,8 @@ fn link_cpp_std() {
     Some("c++".to_string())
   } else if target.contains("android") {
     Some("c++_shared".to_string())
+  } else if target.contains("wasm32") {
+    None
   } else {
     Some("stdc++".to_string())
   };


### PR DESCRIPTION
I was trying to build the library for --target wasm32-unknown-unknown, but no wrappers for classes and methods were being generated.

According to https://github.com/rust-lang/rust-bindgen/issues/751#issuecomment-496891269, the -fvisibility=default flag must be passed to clang.

Also, no c++ should be linked.